### PR TITLE
Fix require + exclude

### DIFF
--- a/char_gen.go
+++ b/char_gen.go
@@ -126,57 +126,48 @@ func (r CharRecipe) Generate() (*Password, error) {
 }
 
 // buildCharacterList constructs the "alphabet" that is all and only those
-// characters (actually strings of length 1) that are all and only those
-// characters from which the password will be build. It also ensures that
-// there are no duplicates
+// characters (actually strings of length 1) from which the password will be
+// built. It also ensures that there are no duplicates.
 func (r *CharRecipe) buildCharacterList() charList {
-
-	ab := r.AllowChars
-	exclude := r.ExcludeChars
-	require := make(reqSets, 0)
+	allowedChars := r.AllowChars
+	excludedChars := r.ExcludeChars
+	r.requiredSets = make(reqSets, 0)
 	for i, s := range r.RequireSets {
 		if len(s) > 0 {
-			require = append(require,
+			r.requiredSets = append(r.requiredSets,
 				*newReqSet(s, fmt.Sprintf("Custom %d", i+1)))
-			ab += s
 		}
 	}
 	for f, ct := range charTypeByFlag {
 		if r.Allow&f != 0 {
-			ab += ct
+			allowedChars += ct
 		}
-		// Require automatically gets added to alphabet and to the require sets
 		if r.Require&f != 0 {
 			ctName, ok := charTypeNamesByFlag[f]
 			if !ok {
 				ctName = "Dunno"
 			}
-			require = append(require, *newReqSet(ct, ctName))
-			ab += ct
+			r.requiredSets = append(r.requiredSets, *newReqSet(ct, ctName))
 		}
 		if r.Exclude&f != 0 {
-			exclude += ct
+			excludedChars += ct
 		}
 	}
 
-	// Now we need to clean this all up. First let's make them
-	// sets.
+	// Now we need to clean this all up. First let's make them sets.
+	excludedSet := setFromString(excludedChars)
+	r.allowedSet = setFromString(allowedChars).Difference(excludedSet)
 
-	exS := setFromString(exclude)
-	r.allowedSet = setFromString(ab)
-	r.allowedSet = r.allowedSet.Difference(exS)
-
-	// now remove excluded from each reqSet
-	// and remove each ReqSet from allowedSet
-	for i := range require {
-		req := &require[i]
-		req.s = req.s.Difference(exS)
+	// Now remove excluded chars from each required set
+	// and remove required chars from the allowed set
+	for i := range r.requiredSets {
+		req := &r.requiredSets[i]
+		req.s = req.s.Difference(excludedSet)
 		r.allowedSet = r.allowedSet.Difference(req.s)
 	}
-	r.requiredSets = require
 
-	fullABCSet := r.allowedSet.Union(r.requiredSets.union().s)
-	return strings.Split(stringFromSet(fullABCSet), "")
+	alphabetSet := r.allowedSet.Union(r.requiredSets.union().s)
+	return strings.Split(stringFromSet(alphabetSet), "")
 }
 
 // Entropy returns the entropy of a character password given the generator attributes

--- a/char_gen.go
+++ b/char_gen.go
@@ -168,7 +168,8 @@ func (r *CharRecipe) buildCharacterList() charList {
 
 	// now remove excluded from each reqSet
 	// and remove each ReqSet from allowedSet
-	for _, req := range require {
+	for i := range require {
+		req := &require[i]
 		req.s = req.s.Difference(exS)
 		r.allowedSet = r.allowedSet.Difference(req.s)
 	}

--- a/char_strength.go
+++ b/char_strength.go
@@ -11,14 +11,7 @@ import (
 // passwords. The trick is for when a character is _required_ from a particular set
 
 func (r CharRecipe) entropyWithRequired() float32 {
-	allowed := set.NewSet()
-	allowed.Add(r.allowedSet)
-	required := set.NewSet()
-	for _, req := range r.requiredSets {
-		required.Add(req.s)
-	}
-
-	intValue := n(allowed, required, r.Length)
+	intValue := r.n()
 	floatValue := big.NewFloat(0).SetInt(intValue)
 
 	// big.Float doesn't have a Log function, so we need to stuff the
@@ -30,6 +23,17 @@ func (r CharRecipe) entropyWithRequired() float32 {
 	}
 
 	return float32(math.Log2(float64Value))
+}
+
+func (r CharRecipe) n() *big.Int {
+	allowed := set.NewSet()
+	allowed.Add(r.allowedSet)
+	required := set.NewSet()
+	for _, req := range r.requiredSets {
+		required.Add(req.s)
+	}
+
+	return n(allowed, required, r.Length)
 }
 
 // n is the number of possible passwords that can be generated.

--- a/char_strength_test.go
+++ b/char_strength_test.go
@@ -3,16 +3,21 @@ package spg
 import (
 	"math"
 	"testing"
-
-	set "github.com/deckarep/golang-set"
 )
 
 // expectation is data for a single entropy test
 type expectation struct {
-	Allowed  []string
-	Required []string
-	Length   int
-	Result   int64
+	Length int
+
+	Allow   CTFlag
+	Require CTFlag
+	Exclude CTFlag
+
+	AllowChars   string
+	RequireSets  []string
+	ExcludeChars string
+
+	N int64
 }
 
 const upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -20,60 +25,67 @@ const lower = "abcdefghijklmnopqrstuvwxyz"
 const digits = "0123456789"
 
 var expectations = []expectation{
-	{Required: []string{""}, Length: 1, Result: 0},
-	{Required: []string{"a"}, Length: 0, Result: 0},
-	{Required: []string{"a"}, Length: 1, Result: 1},
-	{Required: []string{"a"}, Length: 5, Result: 1},
-	{Required: []string{"abcde"}, Length: 1, Result: 5},
-	{Required: []string{"abcde"}, Length: 2, Result: 25},
-	{Required: []string{"a", "1"}, Length: 2, Result: 2},
-	{Required: []string{"ab", "123"}, Length: 2, Result: 12},
+	{RequireSets: []string{""}, Length: 1, N: 0},
+	{RequireSets: []string{"a"}, Length: 0, N: 0},
+	{RequireSets: []string{"a"}, Length: 1, N: 1},
+	{RequireSets: []string{"a"}, Length: 5, N: 1},
+	{RequireSets: []string{"abcde"}, Length: 1, N: 5},
+	{RequireSets: []string{"abcde"}, Length: 2, N: 25},
+	{RequireSets: []string{"a", "1"}, Length: 2, N: 2},
+	{RequireSets: []string{"ab", "123"}, Length: 2, N: 12},
 
-	{Required: []string{upper, lower, digits}, Length: 0, Result: 0},
-	{Required: []string{upper, lower, digits}, Length: 1, Result: 0},
-	{Required: []string{upper, lower, digits}, Length: 2, Result: 0},
-	{Required: []string{upper, lower, digits}, Length: 3, Result: 40560},
-	{Required: []string{upper + lower, digits}, Length: 3, Result: 96720},
+	{Require: Letters | Digits, Length: 0, N: 0},
+	{Require: Letters | Digits, Length: 1, N: 0},
+	{Require: Letters | Digits, Length: 2, N: 0},
+	{Require: Letters | Digits, Length: 3, N: 40560},
+	{RequireSets: []string{upper + lower, digits}, Length: 3, N: 96720},
 
-	{Required: []string{upper}, Length: 3, Result: 17576},
-	{Allowed: []string{upper}, Length: 3, Result: 17576},
-	{Required: []string{upper + lower + digits}, Length: 3, Result: 238328},
-	{Allowed: []string{upper, lower, digits}, Length: 3, Result: 238328},
+	{Require: Uppers, Length: 3, N: 17576},
+	{Allow: Uppers, Length: 3, N: 17576},
+	{RequireSets: []string{upper + lower + digits}, Length: 3, N: 238328},
+	{Allow: Letters | Digits, Length: 3, N: 238328},
 
-	{Required: []string{"a", "1"}, Length: 1, Result: 0},
-	{Required: []string{"a"}, Allowed: []string{"1"}, Length: 1, Result: 1},
-	{Required: []string{"a"}, Allowed: []string{"A", "1"}, Length: 2, Result: 5},
-	{Required: []string{"a"}, Allowed: []string{"A1"}, Length: 2, Result: 5},
-	{Required: []string{"a", "A"}, Allowed: []string{"1"}, Length: 2, Result: 2},
-	{Required: []string{"a", "A"}, Allowed: []string{"1"}, Length: 3, Result: 12},
-}
+	{RequireSets: []string{"a", "1"}, Length: 1, N: 0},
+	{RequireSets: []string{"a"}, AllowChars: "1", Length: 1, N: 1},
+	{RequireSets: []string{"a"}, AllowChars: "A1", Length: 2, N: 5},
+	{RequireSets: []string{"a", "A"}, AllowChars: "1", Length: 2, N: 2},
+	{RequireSets: []string{"a", "A"}, AllowChars: "1", Length: 3, N: 12},
 
-func toSetOfSets(arr []string) set.Set {
-	ret := set.NewSet()
-	for _, str := range arr {
-		ret.Add(setFromString(str))
-	}
-	return ret
+	// Test excluded characters
+	{Allow: Uppers, ExcludeChars: "ABC", Length: 1, N: 23},
+	{Require: Uppers, ExcludeChars: "ABC", Length: 1, N: 23},
+	{RequireSets: []string{"a", "AB"}, AllowChars: "12", ExcludeChars: "B2", Length: 3, N: 12},
 }
 
 func TestN(t *testing.T) {
 	for i, exp := range expectations {
-		result := n(toSetOfSets(exp.Allowed), toSetOfSets(exp.Required), exp.Length)
-		intResult := result.Int64()
+		recipe := &CharRecipe{
+			Length:       exp.Length,
+			Allow:        exp.Allow,
+			Require:      exp.Require,
+			Exclude:      exp.Exclude,
+			AllowChars:   exp.AllowChars,
+			RequireSets:  exp.RequireSets,
+			ExcludeChars: exp.ExcludeChars,
+		}
+		recipe.buildCharacterList()
+		intResult := recipe.n().Int64()
 
-		if intResult != exp.Result {
-			t.Errorf("%d: result should be %d, was %d", i, exp.Result, intResult)
+		if intResult != exp.N {
+			t.Errorf("%d: result should be %d, was %d", i, exp.N, intResult)
 		}
 	}
 }
 
 func TestEntropy(t *testing.T) {
-	recip := &CharRecipe{Length: 2}
-	recip.AllowChars = ""
-	recip.RequireSets = []string{upper, lower, digits}
+	recip := &CharRecipe{
+		Length:      2,
+		AllowChars:  "",
+		RequireSets: []string{upper, lower, digits},
+	}
 	e := recip.Entropy()
 	if !math.IsInf(float64(e), -1) {
-		t.Errorf("entropy should be -Inf, was %f", e)
+		t.Errorf("Length is less than number of required sets: entropy should be -Inf, was %f", e)
 	}
 }
 


### PR DESCRIPTION
A very tiny bug caused us to not exclude characters if they were in a required character set, though we intended to do so. When using `range`, the second value is a _copy_, not a reference to the data in the array.

It was a tiny two-line change, which you can see in the "Fix the bug" commit: a1373e6. The rest of this is just test and code cleanup.

This originally looked like a bug in our entropy calculation since the entropy was higher when using require than when using allow, which should not be the case. But we actually had a larger character set when using require because the ambiguous chars were not being excluded like they were when using allow.