### PR TITLE
SuccessProbability() for meeting requirements on single generation

### DIFF
--- a/char_strength.go
+++ b/char_strength.go
@@ -110,9 +110,9 @@ func unionAll(elements set.Set) set.Set {
 	return combined
 }
 
-// successProbability returns the chances of meeting all of the Require-ments
+// SuccessProbability returns the chances of meeting all of the Require-ments
 // on a single trial.
-func (r CharRecipe) successProbability() float32 {
+func (r CharRecipe) SuccessProbability() float32 {
 
 	/* The probability of generating a password that meets the Requirements
 	   on a single trial is the ratio of r.n()/rWithAllRequiredChangedToAllowed.n()
@@ -124,13 +124,13 @@ func (r CharRecipe) successProbability() float32 {
 
 	newAllowChars := r.AllowChars + strings.Join(r.RequireSets, "")
 	newRequireSets := []string{}
-	rAllow := r
-	rAllow.AllowChars = newAllowChars
-	rAllow.RequireSets = newRequireSets
-	rAllow.Allow = r.Allow | r.Require
-	rAllow.Require = None
+	rCopy := r
+	rCopy.AllowChars = newAllowChars
+	rCopy.RequireSets = newRequireSets
+	rCopy.Allow = r.Allow | r.Require
+	rCopy.Require = None
 
-	eDiff := r.Entropy() - rAllow.Entropy()
+	eDiff := r.Entropy() - rCopy.Entropy()
 	if eDiff > 0.0 {
 		// This should never happen, but I don't want to
 		// log.Fatal in a library

--- a/char_strength.go
+++ b/char_strength.go
@@ -130,7 +130,7 @@ func (r CharRecipe) successProbability() float32 {
 	rAllow.Allow = r.Allow | r.Require
 	rAllow.Require = None
 
-	eDiff := rAllow.Entropy() - r.Entropy()
+	eDiff := r.Entropy() - rAllow.Entropy()
 	if eDiff > 0.0 {
 		// This should never happen, but I don't want to
 		// log.Fatal in a library

--- a/char_strength.go
+++ b/char_strength.go
@@ -1,8 +1,10 @@
 package spg
 
 import (
+	"log"
 	"math"
 	"math/big"
+	"strings"
 
 	set "github.com/deckarep/golang-set"
 )
@@ -106,6 +108,43 @@ func unionAll(elements set.Set) set.Set {
 		}
 	}
 	return combined
+}
+
+// successProbability returns the chances of meeting all of the Require-ments
+// on a single trial.
+func (r CharRecipe) successProbability() float32 {
+
+	/* The probability of generating a password that meets the Requirements
+	   on a single trial is the ratio of r.n()/rWithAllRequiredChangedToAllowed.n()
+
+	   But to avoid having to read the Go docs about big Quotients, replace that
+	   division with a substraction of their logarithms. Conveniently, we have
+	   those as the Entropy. Then we just raise 2 to that difference.
+	*/
+
+	newAllowChars := r.AllowChars + strings.Join(r.RequireSets, "")
+	newRequireSets := []string{}
+	rAllow := r
+	rAllow.AllowChars = newAllowChars
+	rAllow.RequireSets = newRequireSets
+	rAllow.Allow = r.Allow | r.Require
+	rAllow.Require = None
+
+	eDiff := rAllow.Entropy() - r.Entropy()
+	if eDiff > 0.0 {
+		// This should never happen, but I don't want to
+		// log.Fatal in a library
+		log.Println("successProbability: eDiff is positive. Setting to 0")
+		eDiff = 0.0
+	}
+
+	p := float32(math.Exp2(float64(eDiff)))
+	if p > 1.0 {
+		// Can't happen, but still
+		log.Println("successProbability: p greater than 1. Setting to 1")
+		p = 1.0
+	}
+	return p
 }
 
 /**

--- a/char_strength_test.go
+++ b/char_strength_test.go
@@ -109,6 +109,24 @@ func TestSuccessProbability(t *testing.T) {
 	tvecs := []tvec{
 		{Length: 5, Allow: Letters | Digits, P: 1},
 		{Length: 3, RequireSets: []string{"123", "XYZ", "abc", "+*!"}, P: 0},
+
+		{Require: Letters | Digits, Length: 3, P: 40560.0 / 238328.0},
+		{RequireSets: []string{"ab", "123"}, Length: 2, P: 12.0 / 25.0},
+
+		// Following tests were not calculated independently.
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 8, P: 0.444025},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 9, P: 0.521395},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 10, P: 0.588561},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 11, P: 0.646499},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 12, P: 0.696338},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 13, P: 0.739163},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 14, P: 0.775953},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 15, P: 0.807565},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 16, P: 0.834729},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 17, P: 0.858070},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 18, P: 0.878131},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 19, P: 0.895364},
+		{RequireSets: []string{lower, upper, digits, "+-()*&.;$#@"}, Length: 20, P: 0.910173},
 	}
 
 	for i, exp := range tvecs {

--- a/char_strength_test.go
+++ b/char_strength_test.go
@@ -140,7 +140,7 @@ func TestSuccessProbability(t *testing.T) {
 			ExcludeChars: exp.ExcludeChars,
 		}
 		recipe.buildCharacterList()
-		p := recipe.successProbability()
+		p := recipe.SuccessProbability()
 
 		if cmpFloat32(p, exp.P, 10000) != 0 {
 			t.Errorf("%d: result should be %f, was %f", i, exp.P, p)

--- a/char_strength_test.go
+++ b/char_strength_test.go
@@ -89,6 +89,47 @@ func TestEntropy(t *testing.T) {
 	}
 }
 
+// Some tests for probability of Required success
+
+func TestSuccessProbability(t *testing.T) {
+	type tvec struct {
+		Length int
+
+		Allow   CTFlag
+		Require CTFlag
+		Exclude CTFlag
+
+		AllowChars   string
+		RequireSets  []string
+		ExcludeChars string
+
+		P float32
+	}
+
+	tvecs := []tvec{
+		{Length: 5, Allow: Letters | Digits, P: 1},
+		{Length: 3, RequireSets: []string{"123", "XYZ", "abc", "+*!"}, P: 0},
+	}
+
+	for i, exp := range tvecs {
+		recipe := &CharRecipe{
+			Length:       exp.Length,
+			Allow:        exp.Allow,
+			Require:      exp.Require,
+			Exclude:      exp.Exclude,
+			AllowChars:   exp.AllowChars,
+			RequireSets:  exp.RequireSets,
+			ExcludeChars: exp.ExcludeChars,
+		}
+		recipe.buildCharacterList()
+		p := recipe.successProbability()
+
+		if cmpFloat32(p, exp.P, 10000) != 0 {
+			t.Errorf("%d: result should be %f, was %f", i, exp.P, p)
+		}
+	}
+}
+
 /**
  ** Copyright 2018 AgileBits, Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License").


### PR DESCRIPTION
Our way of handing Required character sets involves a generate and reject/filter mechanism. It may be nice what the probability is of having to reject any particular candidate. Callers to CharRecipe.Generate() may wish to know before hand if they are using requirements that are hard to satisfy.

Note that this returns the probability for a single candidate. Internally the generator runs unto 500 trials before giving up. (In practice with realistic settings it should never come close to needed all of those trials.).

Once this PR is merged, we can look at making use of this calculation to reject or warn about specific recipes. But let's have this in place first so that we can easily do the math.