### PR TITLE
Fix random bugs

### DIFF
--- a/char_gen.go
+++ b/char_gen.go
@@ -112,7 +112,7 @@ func (r CharRecipe) Generate() (*Password, error) {
 	for i := 0; i < trials; i++ {
 		tokens := make([]Token, r.Length)
 		for i := 0; i < r.Length; i++ {
-			c := chars[int31n(uint32(len(chars)))]
+			c := chars[randomUint32n(uint32(len(chars)))]
 			tokens[i] = Token{c, AtomType}
 		}
 		p.tokens = tokens

--- a/util.go
+++ b/util.go
@@ -1,7 +1,6 @@
 package spg
 
 import (
-	"bytes"
 	rand "crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -39,23 +38,15 @@ func nFromString(ab string, n int) (string, float64) {
 
 }
 
-// randomInt32 creates a random 32 bit unsigned integer
-func randomInt32() uint32 {
+// randomUint32 creates a random 32 bit unsigned integer
+func randomUint32() uint32 {
 	b := make([]byte, 4)
 	_, err := rand.Read(b)
 	if err != nil {
 		panic("PRNG gen error:" + err.Error())
 	}
 
-	var result int32
-	buf := bytes.NewReader(b)
-	err = binary.Read(buf, binary.LittleEndian, &result)
-
-	if err != nil {
-		panic("PRNG conversion error:" + err.Error())
-	}
-
-	return uint32(result)
+	return binary.BigEndian.Uint32(b)
 }
 
 // entropySimple takes the password length and the number of elements in the alphabet
@@ -84,12 +75,12 @@ func int31n(n uint32) uint32 {
 		panic("invalid argument to int31n")
 	}
 	if n&(n-1) == 0 { // n is power of two, can mask
-		return randomInt32() & (n - 1)
+		return randomUint32() & (n - 1)
 	}
 	max := uint32((1 << 31) - 1 - (1<<31)%uint32(n))
-	v := randomInt32()
+	v := randomUint32()
 	for v > max {
-		v = randomInt32()
+		v = randomUint32()
 	}
 	return v % n
 }

--- a/util.go
+++ b/util.go
@@ -32,7 +32,7 @@ func nFromString(ab string, n int) (string, float64) {
 	sep := ""
 	rAB := strings.Split(ab, "") // an AlphaBet of runes
 	for i := 1; i <= n; i++ {
-		sep += string(rAB[int31n(uint32(len(rAB)))])
+		sep += string(rAB[randomUint32n(uint32(len(rAB)))])
 	}
 	return sep, ent
 
@@ -66,20 +66,21 @@ func entropySimple(length int, nelem int) FloatE {
 	return FloatE(float64(length) * entPerUnit)
 }
 
-// int31n returns, as an int32, a non-negative random number in [0,n) from a cryptographic appropriate source. It panics if n <= 0 or if
-// a security-sensitive random number cannot be created. Care is taken to avoid modulo bias.
+// randomUint32n returns, as a uint32, a non-negative random number in [0,n) from a cryptographic appropriate source.
+// It panics if a security-sensitive random number cannot be created.
+// Care is taken to avoid modulo bias.
 //
-// Copied from the math/rand package..
-func int31n(n uint32) uint32 {
-	if n <= 0 {
-		panic("invalid argument to int31n")
+// Based on Int32n from the math/rand package..
+func randomUint32n(n uint32) uint32 {
+	if n <= 1 {
+		return 0
 	}
 	if n&(n-1) == 0 { // n is power of two, can mask
 		return randomUint32() & (n - 1)
 	}
-	max := uint32((1 << 31) - 1 - (1<<31)%uint32(n))
+	discard := uint32(math.MaxUint32 - math.MaxUint32%n)
 	v := randomUint32()
-	for v > max {
+	for v >= discard {
 		v = randomUint32()
 	}
 	return v % n

--- a/util.go
+++ b/util.go
@@ -70,7 +70,7 @@ func entropySimple(length int, nelem int) FloatE {
 // It panics if a security-sensitive random number cannot be created.
 // Care is taken to avoid modulo bias.
 //
-// Based on Int32n from the math/rand package..
+// Based on Int31n from the math/rand package..
 func randomUint32n(n uint32) uint32 {
 	if n <= 1 {
 		return 0

--- a/util.go
+++ b/util.go
@@ -41,7 +41,7 @@ func nFromString(ab string, n int) (string, float64) {
 
 // randomInt32 creates a random 32 bit unsigned integer
 func randomInt32() uint32 {
-	b := make([]byte, 8)
+	b := make([]byte, 4)
 	_, err := rand.Read(b)
 	if err != nil {
 		panic("PRNG gen error:" + err.Error())

--- a/word_gen.go
+++ b/word_gen.go
@@ -149,11 +149,11 @@ func (r WLRecipe) Generate() (*Password, error) {
 	case CSFirst:
 		capWords[0] = true
 	case CSOne:
-		w := int(int31n(uint32(r.Length)))
+		w := int(randomUint32n(uint32(r.Length)))
 		capWords[w] = true
 	case CSRandom:
 		for i := 1; i <= r.Length; i++ {
-			if int31n(2) == 1 {
+			if randomUint32n(2) == 1 {
 				capWords[i] = true
 			}
 		}
@@ -165,7 +165,7 @@ func (r WLRecipe) Generate() (*Password, error) {
 
 	ts := []Token{}
 	for i := 0; i < r.Length; i++ {
-		w := r.list.words[int31n(uint32(r.Size()))]
+		w := r.list.words[randomUint32n(uint32(r.Size()))]
 
 		if capWords[i] {
 			w = strings.Title(w)


### PR DESCRIPTION
Fixes #5 

1. Don't generate 8 random bytes when we only need 4.
2. Fix performance and non-uniform bug in `int31n`.

Thanks, @Sc00bz!