### PR TITLE
Handle impossible ranges for randomUint32n()

### DIFF
--- a/char_gen.go
+++ b/char_gen.go
@@ -101,6 +101,9 @@ func (r CharRecipe) Generate() (*Password, error) {
 	p.Entropy = r.Entropy()
 
 	chars := r.buildCharacterList()
+	if len(chars) == 0 {
+		return nil, fmt.Errorf("no characters to build pwd from")
+	}
 
 	// If it's impossible to meet requirements, there will be 0 possibilities and entropy will be -Inf.
 	// Entropy of 0 means there's 1 possibility.

--- a/char_strength_test.go
+++ b/char_strength_test.go
@@ -89,6 +89,39 @@ func TestEntropy(t *testing.T) {
 	}
 }
 
+func TestRandomUint32n_Panic(t *testing.T) {
+	// Testing recover state to check for panic.
+	// Lifted from https://stackoverflow.com/a/31596110/1304076
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("should have panicked")
+		}
+	}()
+
+	randomUint32n(0)
+}
+
+func TestRandomUint32n_1(t *testing.T) {
+	if r := randomUint32n(1); r != 0 {
+		t.Errorf("returned %v instead of 0", r)
+	}
+}
+
+func TestGenerator_Impossible(t *testing.T) {
+	recipe := &CharRecipe{
+		Length:       5,
+		AllowChars:   "abc",
+		ExcludeChars: "abc",
+	}
+	pwd, err := recipe.Generate()
+	if err == nil {
+		t.Error("Should have erred on zero length alphabet")
+	}
+	if pwd != nil {
+		t.Errorf("Should not have returned a password (%q) on zero length alphabet", pwd.String())
+	}
+}
+
 /**
  ** Copyright 2018 AgileBits, Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License").

--- a/util.go
+++ b/util.go
@@ -67,12 +67,15 @@ func entropySimple(length int, nelem int) FloatE {
 }
 
 // randomUint32n returns, as a uint32, a non-negative random number in [0,n) from a cryptographic appropriate source.
-// It panics if a security-sensitive random number cannot be created.
+// It panics if a security-sensitive random number cannot be created or if n == 0.
 // Care is taken to avoid modulo bias.
 //
 // Based on Int31n from the math/rand package..
 func randomUint32n(n uint32) uint32 {
-	if n <= 1 {
+	if n < 1 {
+		panic("randomUint32n called with 0")
+	}
+	if n == 1 {
 		return 0
 	}
 	if n&(n-1) == 0 { // n is power of two, can mask

--- a/util.go
+++ b/util.go
@@ -75,9 +75,6 @@ func randomUint32n(n uint32) uint32 {
 	if n < 1 {
 		panic("randomUint32n called with 0")
 	}
-	if n == 1 {
-		return 0
-	}
 	if n&(n-1) == 0 { // n is power of two, can mask
 		return randomUint32() & (n - 1)
 	}


### PR DESCRIPTION
Resolves #7 

- `randomUint32n()` will panic if argument is 0
- `CharRecipe.Generate()` returns error if the character string it builds is length 0
- Tests

Note that `Entropy()` will still return `-Inf` in these pathological cases. So you can attempt to calculate the entropy for such pathological cases. What you do with that `-Inf` is your own business.