### PR TITLE
Use a go import comment for canonical location

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -77,6 +77,6 @@ License
 
 This package is Copyright 2017, 2018 by AgileBits, Inc and is licensed under the Apache 2.0 agreement.
 */
-package spg
+package spg // import "go.1password.io/spg"
 
 // This file is for package documentation only


### PR DESCRIPTION
This adds an `// import "go.1password.io/spg` comment so that go will help out people who end up installing this directly from github.