### PR TITLE
Minor changes to pass gosec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/*/
 *.out
 
 ./opgen
+cmd/opgen/opgen

--- a/char_strength.go
+++ b/char_strength.go
@@ -51,7 +51,7 @@ func n(allowed set.Set, required set.Set, length int) *big.Int {
 	// union of all sets in the password recipe.
 	R := unionAll(allowed.Union(required))
 	totalCount := &big.Int{}
-	totalCount.Exp(toBigInt(R.Cardinality()), toBigInt(length), nil)
+	totalCount.Exp(toBigInt(R.Cardinality()), toBigInt(length), nil) // #nosec
 
 	// Each of these sets of sets represents a password recipe that we
 	// will reject and thus must subtract from our total count.

--- a/char_strength.go
+++ b/char_strength.go
@@ -51,7 +51,7 @@ func n(allowed set.Set, required set.Set, length int) *big.Int {
 	// union of all sets in the password recipe.
 	R := unionAll(allowed.Union(required))
 	totalCount := &big.Int{}
-	totalCount.Exp(toBigInt(R.Cardinality()), toBigInt(length), nil) // #nosec
+	totalCount.Exp(toBigInt(R.Cardinality()), toBigInt(length), nil) // #nosec G105
 
 	// Each of these sets of sets represents a password recipe that we
 	// will reject and thus must subtract from our total count.

--- a/cmd/opgen/opgen.go
+++ b/cmd/opgen/opgen.go
@@ -164,7 +164,11 @@ func parseWordList(value string) *spg.WordList {
 		os.Exit(ExitUsage)
 	}
 
-	wordList, _ := spg.NewWordList(words)
+	wordList, err := spg.NewWordList(words)
+	if err != nil {
+		log.Printf("Error setting up wordlist: %v", err)
+		os.Exit(ExitCatchall)
+	}
 	return wordList
 }
 

--- a/cmd/opgen/opgen.go
+++ b/cmd/opgen/opgen.go
@@ -87,10 +87,16 @@ func main() {
 	// pwd, _ := recipe.Generate()
 	// fmt.Println(pwd.String())
 	case "characters":
-		charactersCommand.Parse(os.Args[2:])
+		if err := charactersCommand.Parse(os.Args[2:]); err != nil {
+			printUsage()
+			os.Exit(ExitUsage)
+		}
 		generator = charGenerator()
 	case "words":
-		wordlistCommand.Parse(os.Args[2:])
+		if err := wordlistCommand.Parse(os.Args[2:]); err != nil {
+			printUsage()
+			os.Exit(ExitUsage)
+		}
 		generator = wlGenerator()
 	default:
 		printUsage()
@@ -195,7 +201,7 @@ func charGenerator() *spg.CharRecipe {
 }
 
 func loadWordListFile(path string) *spg.WordList {
-	data, err := ioutil.ReadFile(path)
+	data, err := ioutil.ReadFile(path) // #nosec G304
 	if err != nil {
 		log.Fatalln("Error opening file:", path, err)
 	}

--- a/word_gen.go
+++ b/word_gen.go
@@ -254,7 +254,11 @@ func NewSFFunction(r CharRecipe) SFFunction {
 // Pre-baked Separator functions
 
 func sfWrap(r CharRecipe) (string, FloatE) {
-	p, _ := r.Generate() // Not sure how to deal with errors here.
+	p, err := r.Generate()
+	// perhaps not the best error handling, but can't think of anything better
+	if err != nil {
+		return "", 0.0
+	}
 	return p.String(), FloatE(p.Entropy)
 }
 


### PR DESCRIPTION
Adds two `#nosec` comments, and adds covers unhandled errors so this now passes a gosec run.

This passes all tests, but we don't have tests for opgen, which is where most of the code changes are.