### PR TITLE
DigitSymbol separator requires both

### DIFF
--- a/separator.go
+++ b/separator.go
@@ -52,6 +52,21 @@ var nullToken = Token{
 	tType: AtomType,
 }
 
+func sfConstantFull(length int, s string) (*Password, error) {
+	ts := make(Tokens, length)
+	for i := range ts {
+		ts[i] = Token{value: s, tType: AtomType}
+	}
+	return &Password{Entropy: 0.0, tokens: ts}, nil
+}
+
+func sfConstant(s string) SFFunction {
+	var sf SFFunction
+	sf = func(length int) (*Password, error) { return sfConstantFull(length, s) }
+	return sf
+
+}
+
 // sfNull generates a separator password of length length with empty tokens
 func sfNull(length int) (*Password, error) {
 	ts := make(Tokens, length)
@@ -61,24 +76,16 @@ func sfNull(length int) (*Password, error) {
 	return &Password{Entropy: 0.0, tokens: ts}, nil
 }
 
-// Pre-baked Separator Recipes
-var (
-	SRDigits1            = SeparatorRecipe{cr: CharRecipe{Allow: Digits}}
-	SRDigitsNoAmbiguous1 = SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}} // Single digit, no ambiguous
-	SRSymbols            = SeparatorRecipe{cr: CharRecipe{Allow: Symbols}}                    // Symbols
-	SRDigitsSymbols      = SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}}           // Symbols and digits
-)
-
 // Pre-baked Separator functions
 var (
-	SFNone               SFFunction = sfNull
-	SFDigits1                       = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits}})                     // Single digit separator
-	SFDigitsNoAmbiguous1            = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}}) // Single digit, no ambiguous
-	SFSymbols                       = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols}})                    // Symbols
-	SFDigitsSymbols                 = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}})           // Symbols and digits
+	SFNone               = sfConstant("")
+	SFDigits1            = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits}})                     // Single digit separator
+	SFDigitsNoAmbiguous1 = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}}) // Single digit, no ambiguous
+	SFSymbols            = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols}})                    // Symbols
+	SFDigitsSymbols      = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}})           // Symbols and digits
 )
 
 /**
- ** Copyright 2018 AgileBits, Inc.
+ ** Copyright 2018, 2019 AgileBits, Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License").
  **/

--- a/separator.go
+++ b/separator.go
@@ -82,7 +82,7 @@ var (
 	SFDigits1            = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits}})                     // Single digit separator
 	SFDigitsNoAmbiguous1 = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}}) // Single digit, no ambiguous
 	SFSymbols            = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols}})                    // Symbols
-	SFDigitsSymbols      = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}})           // Symbols and digits
+	SFDigitsSymbols      = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Require: Symbols | Digits}})         // Symbols and digits
 )
 
 /**

--- a/separator.go
+++ b/separator.go
@@ -45,14 +45,10 @@ type SFFunction func(int) (*Password, error)
 
 // NewSFFunction makes a Separator Function from a CharRecipe
 func NewSFFunction(r SeparatorRecipe) SFFunction {
-	var sf SFFunction
-	sf = func(length int) (*Password, error) { return sfWrap(r, length) }
-	return sf
-}
-
-func sfWrap(sr SeparatorRecipe, length int) (*Password, error) {
-	r := sr.charRecipe(length)
-	return r.Generate()
+	return func(length int) (*Password, error) {
+		cr := r.charRecipe(length)
+		return cr.Generate()
+	}
 }
 
 // sfConstant is for when the separator is constant

--- a/separator.go
+++ b/separator.go
@@ -1,0 +1,84 @@
+package spg
+
+/*** Separator functions
+
+	Wordlist (syllable list) type generators need separators between the words,
+	and creating and setting separator functions is useful. That is what is
+	defined in this section.
+
+***/
+
+// A SeparatorRecipe doesn't necessarily have a length, but it may have
+// a tokenizer instructions for when separator isn't just a single character
+// between words
+type SeparatorRecipe struct {
+	cr CharRecipe
+	t  *sfTokenizer
+}
+
+// sfTokenizer will be instructions for how to tokenize the generated separator
+// string so that its parts can be selected as needed
+type sfTokenizer struct{}
+
+func (sr SeparatorRecipe) charRecipe(length int) *CharRecipe {
+	cr := &sr.cr
+	cr.Length = length
+	return cr
+}
+
+// SFFunctionFull is a type for a function that returns a password
+// which will be used to supply the parts for separating components
+// (to be used within a password) and the entropy it contributes
+type SFFunctionFull func(SeparatorRecipe, int) (Password, error)
+
+// SFFunction is a curried SFFunctionFull, but has already consumed
+// the SeparatorRecipe
+type SFFunction func(int) (*Password, error)
+
+// NewSFFunction makes a Separator Function from a CharRecipe
+func NewSFFunction(r SeparatorRecipe) SFFunction {
+	var sf SFFunction
+	sf = func(length int) (*Password, error) { return sfWrap(r, length) }
+	return sf
+}
+
+func sfWrap(sr SeparatorRecipe, length int) (*Password, error) {
+	r := sr.charRecipe(length)
+	return r.Generate()
+}
+
+var nullToken = Token{
+	value: "",
+	tType: AtomType,
+}
+
+// sfNull generates a separator password of length length with empty tokens
+func sfNull(length int) (*Password, error) {
+	ts := make(Tokens, length)
+	for i := range ts {
+		ts[i] = nullToken
+	}
+	return &Password{Entropy: 0.0, tokens: ts}, nil
+}
+
+// Pre-baked Separator Recipes
+var (
+	SRDigits1            = SeparatorRecipe{cr: CharRecipe{Allow: Digits}}
+	SRDigitsNoAmbiguous1 = SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}} // Single digit, no ambiguous
+	SRSymbols            = SeparatorRecipe{cr: CharRecipe{Allow: Symbols}}                    // Symbols
+	SRDigitsSymbols      = SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}}           // Symbols and digits
+)
+
+// Pre-baked Separator functions
+var (
+	SFNone               SFFunction = sfNull
+	SFDigits1                       = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits}})                     // Single digit separator
+	SFDigitsNoAmbiguous1            = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}}) // Single digit, no ambiguous
+	SFSymbols                       = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols}})                    // Symbols
+	SFDigitsSymbols                 = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}})           // Symbols and digits
+)
+
+/**
+ ** Copyright 2018 AgileBits, Inc.
+ ** Licensed under the Apache License, Version 2.0 (the "License").
+ **/

--- a/word_gen.go
+++ b/word_gen.go
@@ -138,9 +138,13 @@ func (r WLRecipe) Generate() (*Password, error) {
 
 	var sf SFFunction
 	if r.SeparatorFunc == nil {
-		sf = SFFunction(func() (string, FloatE) { return r.SeparatorChar, 0.0 })
+		sf = sfNull
 	} else {
 		sf = r.SeparatorFunc
+	}
+	sepP, err := sf(int(r.Size()) - 1)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate separators: %v", err)
 	}
 
 	// Construct a map of which words to capitalize
@@ -174,7 +178,7 @@ func (r WLRecipe) Generate() (*Password, error) {
 			ts = append(ts, Token{w, AtomType})
 		}
 		if i < r.Length-1 {
-			sep, _ := sf()
+			sep := sepP.tokens[i].value
 			if len(sep) > 0 {
 				ts = append(ts, Token{sep, SeparatorType})
 			}
@@ -209,11 +213,8 @@ func (r WLRecipe) Entropy() float32 {
 	// else there is no additional entropy contribution from capitalization
 
 	// Entropy contribution of separators
-	sepEnt := FloatE(0.0)
-	if r.SeparatorFunc != nil {
-		_, sepEnt = r.SeparatorFunc()
-	}
-	ent += (FloatE(r.Length) - 1.0) * sepEnt
+	sp, _ := r.SeparatorFunc(r.Length)
+	ent += FloatE(sp.Entropy)
 
 	return float32(ent)
 }
@@ -229,86 +230,3 @@ func (wl *WordList) capitalizeRatio() float64 {
 	s := float64(len(wl.words))
 	return (s - float64(wl.unCapitalizableCount)) / s
 }
-
-/*** Separator functions
-
-	Wordlist (syllable list) type generators need separators between the words,
-	and creating and setting separator functions is useful. That is what is
-	defined in this section.
-
-***/
-
-// A SeparatorRecipe doesn't necessarily have a length, but it may have
-// a tokenizer instructions for when separator isn't just a single character
-// between words
-type SeparatorRecipe struct {
-	cr CharRecipe
-	t  *sfTokenizer
-}
-
-// sfTokenizer will be instructions for how to tokenize the generated separator
-// string so that its parts can be selected as needed
-type sfTokenizer struct{}
-
-func (sr SeparatorRecipe) charRecipe(length int) *CharRecipe {
-	cr := &sr.cr
-	cr.Length = length
-	return cr
-}
-
-// SFFunctionFull is a type for a function that returns a password
-// which will be used to supply the parts for separating components
-// (to be used within a password) and the entropy it contributes
-type SFFunctionFull func(SeparatorRecipe, int) (Password, error)
-
-// SFFunction is a curried SFFunctionFull, but has already consumed
-// the SeparatorRecipe
-type SFFunction func(int) (*Password, error)
-
-// NewSFFunction makes a Separator Function from a CharRecipe
-func NewSFFunction(r SeparatorRecipe) SFFunction {
-	var sf SFFunction
-	sf = func(length int) (*Password, error) { return sfWrap(r, length) }
-	return sf
-}
-
-func sfWrap(sr SeparatorRecipe, length int) (*Password, error) {
-	r := sr.charRecipe(length)
-	return r.Generate()
-}
-
-var nullToken = Token{
-	value: "",
-	tType: AtomType,
-}
-
-// sfNull generates a separator password of length length with empty tokens
-func sfNull(length int) (*Password, error) {
-	ts := make(Tokens, length)
-	for i := range ts {
-		ts[i] = nullToken
-	}
-	return &Password{Entropy: 0.0, tokens: ts}, nil
-}
-
-// Pre-baked Separator Recipes
-var (
-	SRDigits1            = SeparatorRecipe{cr: CharRecipe{Allow: Digits}}
-	SRDigitsNoAmbiguous1 = SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}} // Single digit, no ambiguous
-	SRSymbols            = SeparatorRecipe{cr: CharRecipe{Allow: Symbols}}                    // Symbols
-	SRDigitsSymbols      = SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}}           // Symbols and digits
-)
-
-// Pre-baked Separator functions
-var (
-	SFNone               SFFunction = sfNull
-	SFDigits1                       = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits}})                     // Single digit separator
-	SFDigitsNoAmbiguous1            = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Digits, Exclude: Ambiguous}}) // Single digit, no ambiguous
-	SFSymbols                       = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols}})                    // Symbols
-	SFDigitsSymbols                 = NewSFFunction(SeparatorRecipe{cr: CharRecipe{Allow: Symbols | Digits}})           // Symbols and digits
-)
-
-/**
- ** Copyright 2018 AgileBits, Inc.
- ** Licensed under the Apache License, Version 2.0 (the "License").
- **/

--- a/wordlist_test.go
+++ b/wordlist_test.go
@@ -530,6 +530,85 @@ func TestDigitSymbolSeparator(t *testing.T) {
 			t.Errorf("separator p %v should contain a symbol", sPwd)
 		}
 	}
+
+	// and lets make sure that the final generated passwords meet the requirements
+	for i := 0; i < 20; i++ {
+		pwd, err := r.Generate()
+		if err != nil {
+			t.Error(err)
+		}
+		p := pwd.String()
+		if !strings.ContainsAny(p, "0123456789") {
+			t.Errorf("separator p %v should contain a digit", p)
+		}
+		if !strings.ContainsAny(p, ctSymbols) {
+			t.Errorf("separator p %v should contain a symbol", p)
+		}
+	}
+}
+
+func TestDigitSymbolSeparatorShort(t *testing.T) {
+	wl, err := NewWordList([]string{"syl", "lab", "bull", "gen", "er", "at", "or"})
+	if err != nil {
+		t.Errorf("Couldn't create syllable generator: %v", err)
+	}
+	// There will only be two separators, this this will require more work on requirements
+	r := NewWLRecipe(3, wl)
+	r.SeparatorFunc = SFDigitsSymbols
+	r.Capitalize = CSNone
+
+	sf := r.SF()
+
+	for i := 0; i < 20; i++ {
+		sepP, err := sf(r.Length - 1)
+		if err != nil {
+			t.Error(err)
+		}
+		sPwd := sepP.String()
+		if !strings.ContainsAny(sPwd, "0123456789") {
+			t.Errorf("separator p %v should contain a digit", sPwd)
+		}
+		if !strings.ContainsAny(sPwd, ctSymbols) {
+			t.Errorf("separator p %v should contain a symbol", sPwd)
+		}
+	}
+
+	for i := 0; i < 20; i++ {
+		pwd, err := r.Generate()
+		if err != nil {
+			t.Error(err)
+		}
+		p := pwd.String()
+		if !strings.ContainsAny(p, "0123456789") {
+			t.Errorf("separator p %v should contain a digit", p)
+		}
+		if !strings.ContainsAny(p, ctSymbols) {
+			t.Errorf("separator p %v should contain a symbol", p)
+		}
+	}
+}
+
+func TestDigitSymbolSeparatorTooShort(t *testing.T) {
+	wl, err := NewWordList([]string{"syl", "lab", "bull", "gen", "er", "at", "or"})
+	if err != nil {
+		t.Errorf("Couldn't create syllable generator: %v", err)
+	}
+	// This will make meeting the requirements impossible
+	r := NewWLRecipe(2, wl)
+	r.SeparatorFunc = SFDigitsSymbols
+	r.Capitalize = CSNone
+
+	sf := r.SF()
+
+	sepP, err := sf(r.Length - 1)
+	if err == nil {
+		t.Errorf("Should have have been able to generate separator set %v", sepP)
+	}
+
+	pwd, err := r.Generate()
+	if err == nil {
+		t.Errorf("Should have have been able to generate password %v", pwd)
+	}
 }
 
 /**

--- a/wordlist_test.go
+++ b/wordlist_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -502,6 +503,32 @@ func TestNonASCIISeparators(t *testing.T) {
 			t.Errorf("Expected entropy of %q is %.6f. Got %.6f", pw, expectedEnt, ent)
 		}
 		// fmt.Println(pw)
+	}
+}
+
+func TestDigitSymbolSeparator(t *testing.T) {
+	wl, err := NewWordList([]string{"syl", "lab", "bull", "gen", "er", "at", "or"})
+	if err != nil {
+		t.Errorf("Couldn't create syllable generator: %v", err)
+	}
+	r := NewWLRecipe(12, wl)
+	r.SeparatorFunc = SFDigitsSymbols
+	r.Capitalize = CSNone
+
+	sf := r.SF()
+
+	for i := 0; i < 20; i++ {
+		sepP, err := sf(r.Length - 1)
+		if err != nil {
+			t.Error(err)
+		}
+		sPwd := sepP.String()
+		if !strings.ContainsAny(sPwd, "0123456789") {
+			t.Errorf("separator p %v should contain a digit", sPwd)
+		}
+		if !strings.ContainsAny(sPwd, ctSymbols) {
+			t.Errorf("separator p %v should contain a symbol", sPwd)
+		}
 	}
 }
 


### PR DESCRIPTION
Resolves #15

The external changes are that

1. The SFDigitsSymbols requires that at least one digit and at least one symbol appear as separators somewhere. Note that setting this for a pwd with only one separator will fail.

2. The two character separators are no more. (We will be able to bring them back, but it will take some work). I do not believe that anyone was using them or that we exposed those in any UI

3. This exports some new stuff (which needs to be reviewed)

In order to do (1), which is what the issue called for, I needed to change how the separator functions work and how they are used during password generation. So there is a lot of new code in here. This does look a bit ahead to other things which we would like to do with separators.

Note that I will be traveling a great deal over the summer and my availability is limited.

## Concerns before merging

- [ ] Tests of constant separators
- [ ] Tests of proper entropy calculation when using the new separator functions
- [ ] Review of what should and shouldn't be exported
- [ ] Are there better ways to make use of the function type definitions to clean up code.
