### PR TITLE
gitignore: fix patterns to not exclude cmd/opgen/opgen.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 vendor/*/
 !vendor/vendor.json
+
+/opgen
+/cmd/opgen/opgen
+
 ## From github.com/gitignore/Go.gitignore
 # Binaries for programs and plugins
 *.exe
@@ -13,7 +17,3 @@ vendor/*/
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-./opgen
-cmd/opgen/opgen
-opgen


### PR DESCRIPTION
Fix gitignore patterns to not exclude cmd/opgen/opgen.go.

Also, move patterns specific to this project at the top of the file to distinguish them from standard patterns.