### PR TITLE
Remove outdated comment re: vendored dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,6 @@ go get go.1password.io/spg
 ```
 
 
-
-## Vendored dependencies
-
-Before you can successfully build, you may need to install dependencies. These are currently[^1] managed using [`govendor`](https://github.com/kardianos/govendor). Install it if needed,
-
-```
-go get -u github.com/kardianos/govendor
-```
-
-And then use 
-
-```
-govendor sync
-```
-to fetch the appropriate dependencies into `./vendor`
-
-[^1]: We will probably switch to go modules at some point
-
 ## License
 
 1Password's spg is copyright 2018, AgileBits Inc and licensed under [version 2.0 of the Apache License Agreement](./LICENSE).


### PR DESCRIPTION
The repo now has a module defined, so `govendor` is no longer necessary. This PR removes the associated outdated comment from the README file.

Resolves #43 